### PR TITLE
Auto-generate api.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ deps/.rustc_info.json
 deps/*.dylib
 deps/*.so
 deps/build.log
+deps/RustDylib/target
+deps/RustDylib/include
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,9 @@
-authors = ["Felipe Noronha <felipenoris@gmail.com>"]
 name = "JuliaPackageWithRustDep"
 uuid = "b3cfa77a-c005-11e8-2503-c57ef66cec51"
+authors = ["Felipe Noronha <felipenoris@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Clang = "40e3b903-d033-50b4-a0cc-940c62c95e31"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/deps/RustDylib/Cargo.toml
+++ b/deps/RustDylib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "RustDylib"
 version = "0.1.0"
 authors = ["Felipe Noronha <felipenoris@gmail.com>"]
+build="build/build.rs"
 
 [dependencies]
 
@@ -9,3 +10,6 @@ authors = ["Felipe Noronha <felipenoris@gmail.com>"]
 name = "rustdylib"
 crate-type = ["staticlib", "cdylib"]
 
+[build-dependencies]
+
+cbindgen = "0.6.3"

--- a/deps/RustDylib/build/build.rs
+++ b/deps/RustDylib/build/build.rs
@@ -1,0 +1,16 @@
+extern crate cbindgen;
+
+use std::env;
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+
+    if env::var("PROFILE").unwrap()=="release" {
+        cbindgen::Builder::new()
+           .with_crate(crate_dir)
+           .with_language(cbindgen::Language::C)
+           .generate()
+           .expect("Unable to generate bindings")
+           .write_to_file("include/myheader.h");
+    }
+}

--- a/src/JuliaPackageWithRustDep.jl
+++ b/src/JuliaPackageWithRustDep.jl
@@ -11,6 +11,8 @@ function __init__()
     check_deps()
 end
 
+include("api_common.jl")
 include("api.jl")
+
 
 end # module

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,35 +1,39 @@
+# Julia wrapper for header: deps/RustDylib/include/myheader.h
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
 
-function rustdylib_printhello()
-    ccall((:rustdylib_printhello, librustdylib), Cvoid, ())
+
+function rustdylib_abs_f32(i::Cfloat)
+    ccall((:rustdylib_abs_f32, librustdylib), Cfloat, (Cfloat,), i)
 end
 
-function rustdylib_abs_i32(n::Int32)
-    ccall((:rustdylib_abs_i32, librustdylib), Int32, (Int32,), n)
+function rustdylib_abs_f64(i::Cdouble)
+    ccall((:rustdylib_abs_f64, librustdylib), Cdouble, (Cdouble,), i)
 end
 
-function rustdylib_abs_i64(n::Int64)
-    ccall((:rustdylib_abs_i64, librustdylib), Int64, (Int64,), n)
+function rustdylib_abs_i32(i::Int32)
+    ccall((:rustdylib_abs_i32, librustdylib), Int32, (Int32,), i)
 end
 
-function rustdylib_abs_f32(n::Float32)
-    ccall((:rustdylib_abs_f32, librustdylib), Float32, (Float32,), n)
+function rustdylib_abs_i64(i::Int64)
+    ccall((:rustdylib_abs_i64, librustdylib), Int64, (Int64,), i)
 end
 
-function rustdylib_abs_f64(n::Float64)
-    ccall((:rustdylib_abs_f64, librustdylib), Float64, (Float64,), n)
+function rustdylib_free_rust_owned_string(s)
+    ccall((:rustdylib_free_rust_owned_string, librustdylib), Cvoid, (Cstring,), s)
+end
+
+function rustdylib_generate_rust_owned_string()
+    ccall((:rustdylib_generate_rust_owned_string, librustdylib), Cstring, ())
+end
+
+function rustdylib_inspect_string(cstring)
+    ccall((:rustdylib_inspect_string, librustdylib), Cvoid, (Cstring,), cstring)
 end
 
 function rustdylib_is_true_bool(b::Bool)
     ccall((:rustdylib_is_true_bool, librustdylib), Bool, (Bool,), b)
 end
 
-function rustdylib_inspect_string(s::String)
-    ccall((:rustdylib_inspect_string, librustdylib), Cvoid, (Cstring,), s)
-end
-
-function rustdylib_generate_rust_owned_string() :: String
-    cstring = ccall((:rustdylib_generate_rust_owned_string, librustdylib), Ptr{UInt8}, ())
-    result = unsafe_string(cstring)
-    ccall((:rustdylib_free_rust_owned_string, librustdylib), Cvoid, (Ptr{UInt8},), cstring)
-    return result
+function rustdylib_printhello()
+    ccall((:rustdylib_printhello, librustdylib), Cvoid, ())
 end

--- a/src/api_common.jl
+++ b/src/api_common.jl
@@ -1,0 +1,2 @@
+# Automatically generated using Clang.jl wrap_c, version 0.0.0
+

--- a/wrapper/wrap.jl
+++ b/wrapper/wrap.jl
@@ -1,0 +1,11 @@
+using Clang
+
+dir = splitdir(@__FILE__)[1]
+context = wrap_c.init(output_file = joinpath(dir,"../src/api.jl"), clang_diagnostics=true, clang_includes=["/usr/lib/llvm-3.8/lib/clang/3.8.0/include/"],
+    header_wrapped = (p,s)->begin
+        s=="deps/RustDylib/include/myheader.h"
+    end, common_file = joinpath(dir,"../src/api_common.jl"),
+    header_library=x->"librustdylib")
+context.options.wrap_structs=true
+context.headers = ["deps/RustDylib/include/myheader.h"]
+run(context)


### PR DESCRIPTION
This is a modification of the build script so that is uses the `cbindgen` crate to auto-generate c header files for the rust lib. Then on can run the `wrap.jl` script to generate the api.jl file. 

I think for larger projects this is less error-prone than manually generating the api file. 